### PR TITLE
Fix compatibility with Let's Encrypt API changes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 dependencies:
   cache_directories:
+    - build
     - t/build
     - t/tmp
     - t/vendor

--- a/lib/resty/auto-ssl/shell/letsencrypt_hooks
+++ b/lib/resty/auto-ssl/shell/letsencrypt_hooks
@@ -32,11 +32,11 @@ function clean_challenge {
 }
 
 function deploy_cert {
-  local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" CHAINFILE="${4}"
+  local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}" TIMESTAMP="${6}"
 
   local PRIVKEY=$(cat $KEYFILE)
   local CERT=$(cat $CERTFILE)
-  local FULLCHAIN=$(cat $CHAINFILE)
+  local FULLCHAIN=$(cat $FULLCHAINFILE)
 
   curl --silent --show-error --fail -XPOST \
     --header "X-Hook-Secret: $HOOK_SECRET" \
@@ -45,6 +45,10 @@ function deploy_cert {
     --data-urlencode "cert=$CERT" \
     --data-urlencode "fullchain=$FULLCHAIN" \
     "http://127.0.0.1:8999/deploy-cert" || { echo "hook request failed"; exit 1; }
+}
+
+function unchanged_cert {
+  local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}"
 }
 
 HANDLER=$1; shift; $HANDLER $@


### PR DESCRIPTION
Use a newer version of letsencrypt.sh to fix issues that cropped up on 2016-05-18 due to Let's Encrypt pretty printing their JSON output. See https://github.com/lukas2511/letsencrypt.sh/pull/202

Update build and test process to use newer dependencies.