### PR TITLE
Added port-argument to connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Additional configuration options can be set on the `auto_ssl` instance that is c
   ```lua
   auto_ssl:set("redis", {
     host = "10.10.10.1"
+    port = 6379
   })
   ```
 


### PR DESCRIPTION
This field is mandatory when 'host' is used.