### PR TITLE
Refactor the verification of sockproc status

### DIFF
--- a/lib/resty/auto-ssl/utils/start_sockproc.lua
+++ b/lib/resty/auto-ssl/utils/start_sockproc.lua
@@ -2,8 +2,8 @@ local auto_ssl = require "resty.auto-ssl"
 local lock = require "resty.lock"
 
 local function start()
-  local exit_code = os.execute("umask 0022 && " .. auto_ssl.package_root .. "/auto-ssl/shell/start_sockproc")
-  if exit_code == 0 then
+  local exit_status = os.execute("umask 0022 && " .. auto_ssl.package_root .. "/auto-ssl/shell/start_sockproc")
+  if exit_status == 0 or exit_status == true then
     ngx.shared.auto_ssl:set("sockproc_started", true)
   else
     ngx.log(ngx.ERR, "auto-ssl: failed to start sockproc")


### PR DESCRIPTION
Supersedes #17

I have added here an OR logical operator to verify sockproc state (exit_code) against a boolean value (in this case true).

This became necessary from the context when I noticed that exit_code return a boolean true which did not pass the conditional test on line 6 of start_sockproc.lua.

See this Issue for more details #16

cc/ 
@GUI 
@agentzh