### PR TITLE
Add support for Redis' requirepass option (password auth).

### DIFF
--- a/lib/resty/auto-ssl/storage_adapters/redis.lua
+++ b/lib/resty/auto-ssl/storage_adapters/redis.lua
@@ -20,6 +20,13 @@ local function get_redis_instance(self)
     return false, err
   end
 
+  if self.options["auth"] then
+    ok, err = instance:auth(self.options["auth"])
+    if not ok then
+      return false, err
+    end
+  end
+
   ngx.ctx.auto_ssl_redis_instance = instance
   return instance
 end


### PR DESCRIPTION
Hello!

For our setup, we would like to use Redis' password authentication as an extra layer of security.
Since this is a trivial change, I took the liberty to implement it for us, and then create this pull request.

Daniël
