### PR TITLE
make in installation requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Requirements:
   - Or nginx built with [ngx_lua](https://github.com/openresty/lua-nginx-module#installation) 0.10.0 or higher
 - OpenSSL 1.0.2e or higher
 - [LuaRocks](http://openresty.org/#UsingLuaRocks)
-- bash, curl, diff, grep, mktemp, sed (these are generally pre-installed on most systems, but may not be included in some minimal containers)
+- bash, curl, diff, grep, mktemp, sed, make (these are generally pre-installed on most systems, but may not be included in some minimal containers)
 
 
 ```sh


### PR DESCRIPTION
also might be nice to mention with the other commonly pre-installed requirements
```
Using http://luarocks.org/repositories/rocks/lua-resty-http-0.09-0.src.rock... switching to 'build' mode
Archive:  /tmp/luarocks_luarocks-rock-lua-resty-http-0.09-0-6181/lua-resty-http-0.09-0.src.rock
  inflating: lua-resty-http-0.09-0.rockspec  
   creating: lua-resty-http/
   creating: lua-resty-http/t/
  inflating: lua-resty-http/t/06-simpleinterface.t  
  inflating: lua-resty-http/t/08-pipeline.t  
  inflating: lua-resty-http/t/11-proxy.t  
  inflating: lua-resty-http/t/12-case_insensitive_headers.t  
  inflating: lua-resty-http/t/14-host-header.t  
  inflating: lua-resty-http/t/05-stream.t  
  inflating: lua-resty-http/t/03-requestbody.t  
   creating: lua-resty-http/t/cert/
  inflating: lua-resty-http/t/cert/test.key  
  inflating: lua-resty-http/t/cert/test.crt  
  inflating: lua-resty-http/t/02-chunked.t  
  inflating: lua-resty-http/t/07-keepalive.t  
  inflating: lua-resty-http/t/10-clientbodyreader.t  
  inflating: lua-resty-http/t/09-ssl.t  
  inflating: lua-resty-http/t/01-basic.t  
  inflating: lua-resty-http/t/04-trailers.t  
  inflating: lua-resty-http/t/13-default-path.t  
  inflating: lua-resty-http/README.md  
  inflating: lua-resty-http/lua-resty-http-0.09-0.rockspec  
  inflating: lua-resty-http/Makefile  
   creating: lua-resty-http/util/
  inflating: lua-resty-http/util/lua-releng  
  inflating: lua-resty-http/LICENSE  
   creating: lua-resty-http/lib/
   creating: lua-resty-http/lib/resty/
  inflating: lua-resty-http/lib/resty/http.lua  
  inflating: lua-resty-http/lib/resty/http_headers.lua  
Updating manifest for /usr/local/lib/luarocks/rocks

lua-resty-http 0.09-0 is now built and installed in /usr/local/ (license: 2-clause BSD)
Warning: variable CFLAGS was not passed in build_variables
sh: 1: make: not found
```