### PR TITLE
Fix bug in renewal while using a Redis prefix.

### DIFF
--- a/lib/resty/auto-ssl/storage_adapters/redis.lua
+++ b/lib/resty/auto-ssl/storage_adapters/redis.lua
@@ -108,6 +108,19 @@ function _M.keys_with_suffix(self, suffix)
 
   local keys, err = redis_instance:keys(prefixed_key(self, "*" .. suffix))
 
+  if keys and self.options["prefix"] then
+    local unprefixed_keys = {}
+    -- First character past the prefix and a colon
+    local offset = string.len(self.options["prefix"]) + 2
+
+    for _, key in ipairs(keys) do
+      local unprefixed = string.sub(key, offset)
+      table.insert(unprefixed_keys, unprefixed)
+    end
+
+    keys = unprefixed_keys
+  end
+
   return keys, err
 end
 

--- a/t/redis.t
+++ b/t/redis.t
@@ -12,7 +12,7 @@ $redis->expect(10, "now ready") or die "failed to start redis: " . $redis->exp_b
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 7 + 2);
+plan tests => repeat_each() * (blocks() * 7 + 5);
 
 check_accum_error_log();
 no_long_string();
@@ -295,7 +295,7 @@ issuing new certificate for
       storage_adapter = "resty.auto-ssl.storage_adapters.redis",
       redis = {
         port = 9999,
-	prefix = "key-prefix",
+        prefix = "key-prefix",
       },
       allow_domain = function(domain)
         return true
@@ -415,3 +415,135 @@ dehydrated succeeded, but certs still missing from storage
 [error]
 [alert]
 [emerg]
+
+=== TEST 4: renews certificates in the background with a prefix
+--- http_config
+  resolver $TEST_NGINX_RESOLVER;
+  lua_shared_dict auto_ssl 1m;
+
+  init_by_lua_block {
+    auto_ssl = (require "lib.resty.auto-ssl").new({
+      dir = "$TEST_NGINX_RESTY_AUTO_SSL_DIR",
+      ca = "https://acme-staging.api.letsencrypt.org/directory",
+      storage_adapter = "resty.auto-ssl.storage_adapters.redis",
+      redis = {
+        port = 9999,
+        prefix = "key-prefix",
+      },
+      allow_domain = function(domain)
+        return true
+      end,
+      renew_check_interval = 1,
+    })
+    auto_ssl:init()
+  }
+
+  init_worker_by_lua_block {
+    auto_ssl:init_worker()
+  }
+
+  server {
+    listen 9443 ssl;
+    ssl_certificate ../../certs/example_fallback.crt;
+    ssl_certificate_key ../../certs/example_fallback.key;
+    ssl_certificate_by_lua_block {
+      auto_ssl:ssl_certificate()
+    }
+
+    location /foo {
+      server_tokens off;
+      more_clear_headers Date;
+      echo "foo";
+    }
+  }
+
+  server {
+    listen 9080;
+    location /.well-known/acme-challenge/ {
+      content_by_lua_block {
+        auto_ssl:challenge_server()
+      }
+    }
+  }
+
+  server {
+    listen 127.0.0.1:8999;
+    location / {
+      content_by_lua_block {
+        auto_ssl:hook_server()
+      }
+    }
+  }
+--- config
+  lua_ssl_trusted_certificate ../../certs/letsencrypt_staging_chain.pem;
+  lua_ssl_verify_depth 5;
+  location /t {
+    content_by_lua_block {
+      -- Wait for scheduled renewals to happen (since the check interval is
+      -- every 1 second).
+      ngx.sleep(5)
+
+      -- Since we don't actually expect the renewal to happen (since our cert
+      -- is too new), we'll ensure that the "skipping" message gets logged (so
+      -- we're at least sure that the renewal was fired.
+
+      -- Next, ensure that that we're still able to access things using the
+      -- existing certificate even after the renewal was triggered.
+      local sock = ngx.socket.tcp()
+      sock:settimeout(30000)
+      local ok, err = sock:connect("127.0.0.1:9443")
+      if not ok then
+        ngx.say("failed to connect: ", err)
+        return
+      end
+
+      local sess, err = sock:sslhandshake(nil, "$TEST_NGINX_NGROK_HOSTNAME", true)
+      if not sess then
+        ngx.say("failed to do SSL handshake: ", err)
+        return
+      end
+
+      local req = "GET /foo HTTP/1.0\r\nHost: $TEST_NGINX_NGROK_HOSTNAME\r\nConnection: close\r\n\r\n"
+      local bytes, err = sock:send(req)
+      if not bytes then
+        ngx.say("failed to send http request: ", err)
+        return
+      end
+
+      while true do
+        local line, err = sock:receive()
+        if not line then
+          break
+        end
+
+        ngx.say("received: ", line)
+      end
+
+      local ok, err = sock:close()
+      if not ok then
+        ngx.say("failed to close: ", err)
+        return
+      end
+    }
+  }
+--- timeout: 30s
+--- request
+GET /t
+--- response_body
+received: HTTP/1.1 200 OK
+received: Server: openresty
+received: Content-Type: text/plain
+received: Connection: close
+received: 
+received: foo
+--- error_log
+(Longer than 30 days). Skipping
+auto-ssl: checking certificate renewals for
+--- no_error_log
+[warn]
+[error]
+[alert]
+[emerg]
+attempting to renew certificate for domain without certificates in storage
+issuing new certificate for
+


### PR DESCRIPTION
My last PR had a bug with domain renewal (sorry about that!). Domains being fetched from redis were not having the Redis key prefix removed causing all renewal checks to fail. This PR fixes that.