### PR TITLE
WIP: implement new parameter: hook_server_port

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,17 @@ Additional configuration options can be set on the `auto_ssl` instance that is c
   auto_ssl:set("ca", "https://some-other-letsencrypt.org/directory")
   ```
 
+- **`hook_server_port`**
+  *Default:* 8999
+
+  Internally we use a special server server running on port 8999 for handling certificate tasks. The port used for this service may be changed here. Please note that you will also need to change it in your nginx configuration.
+
+  *Example:*
+
+  ```lua
+  auto_ssl:set("hook_server_port", 90)
+  ```
+
 ## Precautions
 
 - **Allowed Hosts:** By default, resty-auto-ssl will not perform any SSL registrations until you define the `allow_domain` function. You may return `true` to handle all possible domains, but be aware that bogus SNI hostnames can then be used to trigger an indefinite number of SSL registration attempts (which will be rejected). A better approach may be to whitelist the allowed domains in some way.

--- a/lib/resty/auto-ssl.lua
+++ b/lib/resty/auto-ssl.lua
@@ -40,6 +40,10 @@ function _M.new(options)
     options["renew_check_interval"] = 86400 -- 1 day
   end
 
+  if not options["hook_server_port"] then
+    options["hook_server_port"] = 8999
+  end
+
   return setmetatable({ options = options }, { __index = _M })
 end
 

--- a/lib/resty/auto-ssl/shell/letsencrypt_hooks
+++ b/lib/resty/auto-ssl/shell/letsencrypt_hooks
@@ -17,7 +17,7 @@ function deploy_challenge {
     --data-urlencode "domain=$DOMAIN" \
     --data-urlencode "token_filename=$TOKEN_FILENAME" \
     --data-urlencode "token_value=$TOKEN_VALUE" \
-    "http://127.0.0.1:8999/deploy-challenge"
+    "http://127.0.0.1:$HOOK_SERVER_PORT/deploy-challenge"
 }
 
 function clean_challenge {
@@ -28,7 +28,7 @@ function clean_challenge {
     --data-urlencode "domain=$DOMAIN" \
     --data-urlencode "token_filename=$TOKEN_FILENAME" \
     --data-urlencode "token_value=$TOKEN_VALUE" \
-    "http://127.0.0.1:8999/clean-challenge" || { echo "hook request failed"; exit 1; }
+    "http://127.0.0.1:$HOOK_SERVER_PORT/clean-challenge" || { echo "hook request failed"; exit 1; }
 }
 
 function deploy_cert {
@@ -44,7 +44,7 @@ function deploy_cert {
     --data-urlencode "privkey=$PRIVKEY" \
     --data-urlencode "cert=$CERT" \
     --data-urlencode "fullchain=$FULLCHAIN" \
-    "http://127.0.0.1:8999/deploy-cert" || { echo "hook request failed"; exit 1; }
+    "http://127.0.0.1:$HOOK_SERVER_PORT/deploy-cert" || { echo "hook request failed"; exit 1; }
 }
 
 function unchanged_cert {

--- a/lib/resty/auto-ssl/ssl_providers/lets_encrypt.lua
+++ b/lib/resty/auto-ssl/ssl_providers/lets_encrypt.lua
@@ -5,10 +5,14 @@ local shell_execute = require "resty.auto-ssl.utils.shell_execute"
 function _M.issue_cert(auto_ssl_instance, domain)
   local package_root = auto_ssl_instance.package_root
   local base_dir = auto_ssl_instance:get("dir")
+  local hook_port = auto_ssl_instance:get("hook_server_port")
+
+  assert(type(hook_port) == "number", "hook_port must be a number")
+  assert(hook_port <= 65535, "hook_port must be below 65536")
 
   local env_vars =
     "env HOOK_SECRET=" .. ngx.shared.auto_ssl:get("hook_server:secret") .. " " ..
-    "HOOK_SERVER_PORT=" .. auto_ssl_instance:get("hook_server_port")
+    "HOOK_SERVER_PORT=" .. hook_port
 
   -- Run dehydrated for this domain, using our custom hooks to handle the
   -- domain validation and the issued certificates.

--- a/lib/resty/auto-ssl/ssl_providers/lets_encrypt.lua
+++ b/lib/resty/auto-ssl/ssl_providers/lets_encrypt.lua
@@ -6,12 +6,16 @@ function _M.issue_cert(auto_ssl_instance, domain)
   local package_root = auto_ssl_instance.package_root
   local base_dir = auto_ssl_instance:get("dir")
 
+  local env_vars =
+    "env HOOK_SECRET=" .. ngx.shared.auto_ssl:get("hook_server:secret") .. " " ..
+    "HOOK_SERVER_PORT=" .. auto_ssl_instance:get("hook_server_port")
+
   -- Run dehydrated for this domain, using our custom hooks to handle the
   -- domain validation and the issued certificates.
   --
   -- Disable dehydrated's locking, since we perform our own domain-specific
   -- locking using the storage adapter.
-  local command = "env HOOK_SECRET=" .. ngx.shared.auto_ssl:get("hook_server:secret") .. " " ..
+  local command = env_vars .. " " ..
     package_root .. "/auto-ssl/vendor/dehydrated " ..
     "--cron " ..
     "--no-lock " ..
@@ -40,7 +44,7 @@ function _M.issue_cert(auto_ssl_instance, domain)
   if not fullchain_pem or not privkey_pem then
     ngx.log(ngx.WARN, "auto-ssl: dehydrated succeeded, but certs still missing from storage - trying to manually copy - domain: " .. domain)
 
-    command = "env HOOK_SECRET=" .. ngx.shared.auto_ssl:get("hook_server:secret") .. " " ..
+    command = env_vars .. " " ..
       package_root .. "/auto-ssl/shell/letsencrypt_hooks " ..
       "deploy_cert " ..
       domain .. " " ..

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1166,3 +1166,113 @@ auto-ssl: dehydrated succeeded, but certs still missing from storage - trying to
 [error]
 [alert]
 [emerg]
+
+=== TEST 11: hook server port can be changed
+--- http_config
+  resolver $TEST_NGINX_RESOLVER;
+  lua_shared_dict auto_ssl 1m;
+
+  init_by_lua_block {
+    auto_ssl = (require "lib.resty.auto-ssl").new({
+      dir = "$TEST_NGINX_RESTY_AUTO_SSL_DIR",
+      hook_server_port = 9888,
+      ca = "https://acme-staging.api.letsencrypt.org/directory",
+      allow_domain = function(domain)
+        return true
+      end,
+    })
+    auto_ssl:init()
+  }
+
+  init_worker_by_lua_block {
+    auto_ssl:init_worker()
+  }
+
+  server {
+    listen 9443 ssl;
+    ssl_certificate ../../certs/example_fallback.crt;
+    ssl_certificate_key ../../certs/example_fallback.key;
+    ssl_certificate_by_lua_block {
+      auto_ssl:ssl_certificate()
+    }
+
+    location /foo {
+      server_tokens off;
+      more_clear_headers Date;
+      echo "foo";
+    }
+  }
+
+  server {
+    listen 9080;
+    location /.well-known/acme-challenge/ {
+      content_by_lua_block {
+        auto_ssl:challenge_server()
+      }
+    }
+  }
+
+  server {
+    listen 127.0.0.1:9888;
+    location / {
+      content_by_lua_block {
+        auto_ssl:hook_server()
+      }
+    }
+  }
+--- config
+  lua_ssl_trusted_certificate ../../certs/letsencrypt_staging_chain.pem;
+  lua_ssl_verify_depth 5;
+  location /t {
+    content_by_lua_block {
+      local sock = ngx.socket.tcp()
+      sock:settimeout(30000)
+      local ok, err = sock:connect("127.0.0.1:9443")
+      if not ok then
+        ngx.say("failed to connect: ", err)
+        return
+      end
+
+      local sess, err = sock:sslhandshake(nil, "$TEST_NGINX_NGROK_HOSTNAME", true)
+      if not sess then
+        ngx.say("failed to do SSL handshake: ", err)
+        return
+      end
+
+      local req = "GET /foo HTTP/1.0\r\nHost: $TEST_NGINX_NGROK_HOSTNAME\r\nConnection: close\r\n\r\n"
+      local bytes, err = sock:send(req)
+      if not bytes then
+        ngx.say("failed to send http request: ", err)
+        return
+      end
+
+      while true do
+        local line, err = sock:receive()
+        if not line then
+          break
+        end
+
+        ngx.say("received: ", line)
+      end
+
+      local ok, err = sock:close()
+      if not ok then
+        ngx.say("failed to close: ", err)
+        return
+      end
+    }
+  }
+--- timeout: 30s
+--- request
+GET /t
+--- response_body
+received: HTTP/1.1 200 OK
+received: Server: openresty
+received: Content-Type: text/plain
+received: Connection: close
+received: 
+received: foo
+--- error_log
+--- no_error_log
+[alert]
+[emerg]


### PR DESCRIPTION
fixes #34 

**TODO**
- [x] add a new parameter named `hook_server_port`
  - [x] check that the new parameter contains a number below 65536
  - [x] make it default to `8999`
- [x] respect value in [letsencrypt_hooks#L20](https://github.com/GUI/lua-resty-auto-ssl/blob/master/lib/resty/auto-ssl/shell/letsencrypt_hooks#L20)
- [x] respect value in [letsencrypt_hooks#L31](https://github.com/GUI/lua-resty-auto-ssl/blob/master/lib/resty/auto-ssl/shell/letsencrypt_hooks#L31)
- [x] write tests
  - [x] change the port
  - [x] default to `8999`
- [x] document new parameter in README