### PR TITLE
Merge certificates with a common second-level domain name into a sing…

### DIFF
--- a/lib/resty/auto-ssl/ssl_certificate.lua
+++ b/lib/resty/auto-ssl/ssl_certificate.lua
@@ -83,7 +83,10 @@ local function issue_cert(auto_ssl_instance, storage, domain)
   end
 
   ngx.log(ngx.NOTICE, "auto-ssl: issuing new certificate for ", domain)
-  fullchain_pem, privkey_pem, err = ssl_provider.issue_cert(auto_ssl_instance, domain)
+  local storage = auto_ssl_instance:get("storage")
+  local d, s = storage:get_domains(domain)
+  storage:set_subdomains(d, s)
+  fullchain_pem, privkey_pem, err = ssl_provider.issue_cert(auto_ssl_instance, domain)  
   if err then
     ngx.log(ngx.ERR, "auto-ssl: issuing new certificate failed: ", err)
   end
@@ -207,7 +210,9 @@ local function set_cert(auto_ssl_instance, domain, fullchain_der, privkey_der, n
   end
 
   -- Set OCSP stapling.
-  ok, err = set_ocsp_stapling(domain, fullchain_der, newly_issued)
+  local storage = auto_ssl_instance:get("storage")
+  local d, s = storage:get_domains(domain)
+  ok, err = set_ocsp_stapling(d, fullchain_der, newly_issued)
   if not ok then
     ngx.log(auto_ssl_instance:get("ocsp_stapling_error_level"), "auto-ssl: failed to set ocsp stapling for ", domain, " - continuing anyway - ", err)
   end

--- a/lib/resty/auto-ssl/ssl_providers/lets_encrypt.lua
+++ b/lib/resty/auto-ssl/ssl_providers/lets_encrypt.lua
@@ -14,16 +14,35 @@ function _M.issue_cert(auto_ssl_instance, domain)
     "env HOOK_SECRET=" .. ngx.shared.auto_ssl:get("hook_server:secret") .. " " ..
     "HOOK_SERVER_PORT=" .. hook_port
 
+  -- The result of running that command should result in the certs being
+  -- populated in our storage (due to the deploy_cert hook triggering).
+  local storage = auto_ssl_instance:get("storage")
+  local fullchain_pem, privkey_pem = storage:get_cert(domain)
+
   -- Run dehydrated for this domain, using our custom hooks to handle the
   -- domain validation and the issued certificates.
   --
   -- Disable dehydrated's locking, since we perform our own domain-specific
   -- locking using the storage adapter.
+  local dom, z = storage:get_domains(domain)
+  local d, zz = storage:get_subdomains(dom)
+  function get_domain_list(domain)
+    local str = ''
+    for _, i in pairs(domain) do
+      str = str .. "--domain " .. i .. " "
+    end
+    return str
+  end
+  if d then
+    domainus = get_domain_list(d)
+  else
+    domainus = "--domain " .. z .. " "
+  end
   local command = env_vars .. " " ..
     package_root .. "/auto-ssl/vendor/dehydrated " ..
     "--cron " ..
     "--no-lock " ..
-    "--domain " .. domain .. " " ..
+    domainus ..
     "--challenge http-01 " ..
     "--config " .. base_dir .. "/letsencrypt/config " ..
     "--hook " .. package_root .. "/auto-ssl/shell/letsencrypt_hooks"
@@ -35,10 +54,6 @@ function _M.issue_cert(auto_ssl_instance, domain)
 
   ngx.log(ngx.DEBUG, "auto-ssl: dehydrated output: " .. out)
 
-  -- The result of running that command should result in the certs being
-  -- populated in our storage (due to the deploy_cert hook triggering).
-  local storage = auto_ssl_instance:get("storage")
-  local fullchain_pem, privkey_pem = storage:get_cert(domain)
 
   -- If dehydrated said it succeeded, but we still don't have any certs in
   -- storage, the issue is likely that the certs have been deleted out of our
@@ -47,22 +62,39 @@ function _M.issue_cert(auto_ssl_instance, domain)
   -- storage with dehydrated's local copies.
   if not fullchain_pem or not privkey_pem then
     ngx.log(ngx.WARN, "auto-ssl: dehydrated succeeded, but certs still missing from storage - trying to manually copy - domain: " .. domain)
-
-    command = env_vars .. " " ..
-      package_root .. "/auto-ssl/shell/letsencrypt_hooks " ..
-      "deploy_cert " ..
-      domain .. " " ..
-      base_dir .. "/letsencrypt/certs/" .. domain .. "/privkey.pem " ..
-      base_dir .. "/letsencrypt/certs/" .. domain .. "/cert.pem " ..
-      base_dir .. "/letsencrypt/certs/" .. domain .. "/fullchain.pem " ..
-      base_dir .. "/letsencrypt/certs/" .. domain .. "/chain.pem " ..
-      math.floor(ngx.now())
-    status, out, err = shell_execute(command)
-    if status ~= 0 then
-      ngx.log(ngx.ERR, "auto-ssl: dehydrated manual hook.sh failed: ", command, " status: ", status, " out: ", out, " err: ", err)
-      return nil, nil, "dehydrated failure"
+    if d then
+      for _, i in pairs(d) do
+        command = env_vars .. " " ..
+          package_root .. "/auto-ssl/shell/letsencrypt_hooks " ..
+          "deploy_cert " ..
+          i .. " " ..
+          base_dir .. "/letsencrypt/certs/" .. i .. "/privkey.pem " ..
+          base_dir .. "/letsencrypt/certs/" .. i .. "/cert.pem " ..
+          base_dir .. "/letsencrypt/certs/" .. i .. "/fullchain.pem " ..
+          base_dir .. "/letsencrypt/certs/" .. i .. "/chain.pem " ..
+          math.floor(ngx.now())
+        status, out, err = shell_execute(command)
+        if status ~= 0 then
+          ngx.log(ngx.ERR, "auto-ssl: dehydrated manual hook.sh failed: ", command, " status: ", status, " out: ", out, " err: ", err)
+          return nil, nil, "dehydrated failure"
+        end
+      end
+    else
+      command = env_vars .. " " ..
+        package_root .. "/auto-ssl/shell/letsencrypt_hooks " ..
+        "deploy_cert " ..
+        z .. " " ..
+        base_dir .. "/letsencrypt/certs/" .. z .. "/privkey.pem " ..
+        base_dir .. "/letsencrypt/certs/" .. z .. "/cert.pem " ..
+        base_dir .. "/letsencrypt/certs/" .. z .. "/fullchain.pem " ..
+        base_dir .. "/letsencrypt/certs/" .. z .. "/chain.pem " ..
+        math.floor(ngx.now())
+      status, out, err = shell_execute(command)
+      if status ~= 0 then
+        ngx.log(ngx.ERR, "auto-ssl: dehydrated manual hook.sh failed: ", command, " status: ", status, " out: ", out, " err: ", err)
+        return nil, nil, "dehydrated failure"
+      end
     end
-
     -- Try fetching again.
     fullchain_pem, privkey_pem = storage:get_cert(domain)
   end


### PR DESCRIPTION
Merge certificates with a common second-level domain name into a single certificate with multiple sub-names.

This should help keep the limit on calls to let's encrypt api in the event that there are many third-level domains on the server.