### PR TITLE
Increase the suggested body buffer size for the HTTP hook server

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ http {
   # Internal server running on port 8999 for handling certificate tasks.
   server {
     listen 127.0.0.1:8999;
+
+    # Increase the body buffer size, to ensure the internal POSTs can always
+    # parse the full POST contents into memory.
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
+
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()

--- a/lib/resty/auto-ssl/servers/hook.lua
+++ b/lib/resty/auto-ssl/servers/hook.lua
@@ -4,14 +4,19 @@
 -- that can be shared across multiple servers, so this can work in a
 -- multi-server, load-balanced environment).
 return function(auto_ssl_instance)
-  ngx.req.read_body()
-  local path = ngx.var.request_uri
-  local params = ngx.req.get_post_args()
-
   if ngx.var.http_x_hook_secret ~= ngx.shared.auto_ssl_settings:get("hook_server:secret") then
-    return ngx.exit(ngx.HTTP_FORBIDDEN)
+    ngx.log(ngx.ERR, "auto-ssl: unauthorized access to hook server (hook secret did not match)")
+    return ngx.exit(ngx.HTTP_UNAUTHORIZED)
   end
 
+  ngx.req.read_body()
+  local params, params_err = ngx.req.get_post_args()
+  if not params then
+    ngx.log(ngx.ERR, "auto-ssl: failed to parse POST args: ", params_err)
+    return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+  end
+
+  local path = ngx.var.request_uri
   local storage = auto_ssl_instance:get("storage")
   if path == "/deploy-challenge" then
     assert(params["domain"])
@@ -20,6 +25,7 @@ return function(auto_ssl_instance)
     local _, err = storage:set_challenge(params["domain"], params["token_filename"], params["token_value"])
     if err then
       ngx.log(ngx.ERR, "auto-ssl: failed to set challenge: ", err)
+      return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
     end
   elseif path == "/clean-challenge" then
     assert(params["domain"])
@@ -27,6 +33,7 @@ return function(auto_ssl_instance)
     local _, err = storage:delete_challenge(params["domain"], params["token_filename"])
     if err then
       ngx.log(ngx.ERR, "auto-ssl: failed to delete challenge: ", err)
+      return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
     end
   elseif path == "/deploy-cert" then
     assert(params["domain"])
@@ -35,6 +42,10 @@ return function(auto_ssl_instance)
     local _, err = storage:set_cert(params["domain"], params["fullchain"], params["privkey"], params["cert"])
     if err then
       ngx.log(ngx.ERR, "auto-ssl: failed to set cert: ", err)
+      return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
     end
+  else
+    ngx.log(ngx.ERR, "auto-ssl: unknown request to hook server: ", path)
+    return ngx.exit(ngx.HTTP_NOT_FOUND)
   end
 end

--- a/t/file.t
+++ b/t/file.t
@@ -64,6 +64,8 @@ __DATA__
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -190,6 +192,8 @@ auto-ssl: issuing new certificate for
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()

--- a/t/hook_server.t
+++ b/t/hook_server.t
@@ -1,0 +1,400 @@
+use strict;
+use warnings;
+use Test::Nginx::Socket::Lua;
+require "./t/inc/setup.pl";
+AutoSsl::setup();
+
+repeat_each(1);
+
+plan tests => repeat_each() * (blocks() * 6);
+
+no_long_string();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: without secret
+--- http_config
+  resolver $TEST_NGINX_RESOLVER;
+  lua_shared_dict auto_ssl 1m;
+  lua_shared_dict auto_ssl_settings 64k;
+
+  init_by_lua_block {
+    auto_ssl = (require "resty.auto-ssl").new({
+      dir = "$TEST_NGINX_RESTY_AUTO_SSL_DIR",
+      ca = "https://acme-staging.api.letsencrypt.org/directory",
+      storage_adapter = "resty.auto-ssl.storage_adapters.file",
+      allow_domain = function(domain)
+        return true
+      end,
+    })
+    auto_ssl:init()
+  }
+
+  init_worker_by_lua_block {
+    auto_ssl:init_worker()
+  }
+
+  server {
+    listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
+    location / {
+      content_by_lua_block {
+        auto_ssl:hook_server()
+      }
+    }
+  }
+--- config
+  location /t {
+    content_by_lua_block {
+      local http = require "resty.http"
+
+      local httpc = http.new()
+      local res, err = httpc:request_uri("http://127.0.0.1:8999/", {
+        method = "POST",
+        body = "a=1&b=2",
+        headers = {
+          ["Content-Type"] = "application/x-www-form-urlencoded",
+        },
+      })
+      ngx.say("Status: " .. res.status)
+    }
+  }
+--- request
+GET /t
+--- response_body
+Status: 401
+--- error_log
+auto-ssl: unauthorized access to hook server (hook secret did not match)
+--- no_error_log
+[warn]
+[alert]
+[emerg]
+
+=== TEST 2: unknown path
+--- http_config
+  resolver $TEST_NGINX_RESOLVER;
+  lua_shared_dict auto_ssl 1m;
+  lua_shared_dict auto_ssl_settings 64k;
+
+  init_by_lua_block {
+    auto_ssl = (require "resty.auto-ssl").new({
+      dir = "$TEST_NGINX_RESTY_AUTO_SSL_DIR",
+      ca = "https://acme-staging.api.letsencrypt.org/directory",
+      storage_adapter = "resty.auto-ssl.storage_adapters.file",
+      allow_domain = function(domain)
+        return true
+      end,
+    })
+    auto_ssl:init()
+  }
+
+  init_worker_by_lua_block {
+    auto_ssl:init_worker()
+  }
+
+  server {
+    listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
+    location / {
+      content_by_lua_block {
+        auto_ssl:hook_server()
+      }
+    }
+  }
+--- config
+  location /t {
+    content_by_lua_block {
+      local http = require "resty.http"
+
+      local httpc = http.new()
+      local res, err = httpc:request_uri("http://127.0.0.1:8999/foobar", {
+        method = "POST",
+        body = "a=1&b=2",
+        headers = {
+          ["X-Hook-Secret"] = ngx.shared.auto_ssl_settings:get("hook_server:secret"),
+          ["Content-Type"] = "application/x-www-form-urlencoded",
+        },
+      })
+      ngx.say("Status: " .. res.status)
+    }
+  }
+--- request
+GET /t
+--- response_body
+Status: 404
+--- error_log
+auto-ssl: unknown request to hook server: /foobar
+--- no_error_log
+[warn]
+[alert]
+[emerg]
+
+=== TEST 3: missing POST args
+--- http_config
+  resolver $TEST_NGINX_RESOLVER;
+  lua_shared_dict auto_ssl 1m;
+  lua_shared_dict auto_ssl_settings 64k;
+
+  init_by_lua_block {
+    auto_ssl = (require "resty.auto-ssl").new({
+      dir = "$TEST_NGINX_RESTY_AUTO_SSL_DIR",
+      ca = "https://acme-staging.api.letsencrypt.org/directory",
+      storage_adapter = "resty.auto-ssl.storage_adapters.file",
+      allow_domain = function(domain)
+        return true
+      end,
+    })
+    auto_ssl:init()
+  }
+
+  init_worker_by_lua_block {
+    auto_ssl:init_worker()
+  }
+
+  server {
+    listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
+    location / {
+      content_by_lua_block {
+        auto_ssl:hook_server()
+      }
+    }
+  }
+--- config
+  location /t {
+    content_by_lua_block {
+      local http = require "resty.http"
+
+      local httpc = http.new()
+      local res, err = httpc:request_uri("http://127.0.0.1:8999/deploy-challenge", {
+        method = "POST",
+        body = "foo=bar",
+        headers = {
+          ["X-Hook-Secret"] = ngx.shared.auto_ssl_settings:get("hook_server:secret"),
+          ["Content-Type"] = "application/x-www-form-urlencoded",
+        },
+      })
+      ngx.say("Status: " .. res.status)
+    }
+  }
+--- request
+GET /t
+--- response_body
+Status: 500
+--- error_log
+assertion failed!
+--- no_error_log
+[warn]
+[alert]
+[emerg]
+
+=== TEST 4: POST body execeeds allowed size
+--- http_config
+  resolver $TEST_NGINX_RESOLVER;
+  lua_shared_dict auto_ssl 1m;
+  lua_shared_dict auto_ssl_settings 64k;
+
+  init_by_lua_block {
+    auto_ssl = (require "resty.auto-ssl").new({
+      dir = "$TEST_NGINX_RESTY_AUTO_SSL_DIR",
+      ca = "https://acme-staging.api.letsencrypt.org/directory",
+      storage_adapter = "resty.auto-ssl.storage_adapters.file",
+      allow_domain = function(domain)
+        return true
+      end,
+    })
+    auto_ssl:init()
+  }
+
+  init_worker_by_lua_block {
+    auto_ssl:init_worker()
+  }
+
+  server {
+    listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
+    location / {
+      content_by_lua_block {
+        auto_ssl:hook_server()
+      }
+    }
+  }
+--- config
+  location /t {
+    content_by_lua_block {
+      local http = require "resty.http"
+      local resty_random = require "resty.random"
+      local str = require "resty.string"
+
+      local httpc = http.new()
+      local res, err = httpc:request_uri("http://127.0.0.1:8999/deploy-challenge", {
+        method = "POST",
+        body = str.to_hex(resty_random.bytes(256000)),
+        headers = {
+          ["X-Hook-Secret"] = ngx.shared.auto_ssl_settings:get("hook_server:secret"),
+          ["Content-Type"] = "application/x-www-form-urlencoded",
+        },
+      })
+      ngx.say("Status: " .. res.status)
+    }
+  }
+--- request
+GET /t
+--- response_body
+Status: 413
+--- error_log
+client intended to send too large body
+--- no_error_log
+[warn]
+[alert]
+[emerg]
+
+=== TEST 5: POST body execeeds buffer size
+--- http_config
+  resolver $TEST_NGINX_RESOLVER;
+  lua_shared_dict auto_ssl 1m;
+  lua_shared_dict auto_ssl_settings 64k;
+
+  init_by_lua_block {
+    auto_ssl = (require "resty.auto-ssl").new({
+      dir = "$TEST_NGINX_RESTY_AUTO_SSL_DIR",
+      ca = "https://acme-staging.api.letsencrypt.org/directory",
+      storage_adapter = "resty.auto-ssl.storage_adapters.file",
+      allow_domain = function(domain)
+        return true
+      end,
+    })
+    auto_ssl:init()
+  }
+
+  init_worker_by_lua_block {
+    auto_ssl:init_worker()
+  }
+
+  server {
+    listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 1m;
+    location / {
+      content_by_lua_block {
+        auto_ssl:hook_server()
+      }
+    }
+  }
+--- config
+  location /t {
+    content_by_lua_block {
+      local http = require "resty.http"
+      local resty_random = require "resty.random"
+      local str = require "resty.string"
+
+      local httpc = http.new()
+      local res, err = httpc:request_uri("http://127.0.0.1:8999/deploy-challenge", {
+        method = "POST",
+        body = str.to_hex(resty_random.bytes(256000)),
+        headers = {
+          ["X-Hook-Secret"] = ngx.shared.auto_ssl_settings:get("hook_server:secret"),
+          ["Content-Type"] = "application/x-www-form-urlencoded",
+        },
+      })
+      ngx.say("Status: " .. res.status)
+    }
+  }
+--- request
+GET /t
+--- response_body
+Status: 500
+--- error_log
+a client request body is buffered to a temporary file
+auto-ssl: failed to parse POST args: request body in temp file not supported
+--- no_error_log
+[alert]
+[emerg]
+
+=== TEST 6: successful deploy-challenge
+--- http_config
+  resolver $TEST_NGINX_RESOLVER;
+  lua_shared_dict auto_ssl 1m;
+  lua_shared_dict auto_ssl_settings 64k;
+
+  init_by_lua_block {
+    auto_ssl = (require "resty.auto-ssl").new({
+      dir = "$TEST_NGINX_RESTY_AUTO_SSL_DIR",
+      ca = "https://acme-staging.api.letsencrypt.org/directory",
+      storage_adapter = "resty.auto-ssl.storage_adapters.file",
+      allow_domain = function(domain)
+        return true
+      end,
+    })
+    auto_ssl:init()
+  }
+
+  init_worker_by_lua_block {
+    auto_ssl:init_worker()
+  }
+
+  server {
+    listen 9080;
+    location /.well-known/acme-challenge/ {
+      content_by_lua_block {
+        auto_ssl:challenge_server()
+      }
+    }
+  }
+
+  server {
+    listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
+    location / {
+      content_by_lua_block {
+        auto_ssl:hook_server()
+      }
+    }
+  }
+--- config
+  location /t {
+    content_by_lua_block {
+      local http = require "resty.http"
+      local resty_random = require "resty.random"
+      local str = require "resty.string"
+
+      local httpc = http.new()
+      local res, err = httpc:request_uri("http://127.0.0.1:8999/deploy-challenge", {
+        method = "POST",
+        body = "domain=example.com&token_filename=foo&token_value=bar",
+        headers = {
+          ["X-Hook-Secret"] = ngx.shared.auto_ssl_settings:get("hook_server:secret"),
+          ["Content-Type"] = "application/x-www-form-urlencoded",
+        },
+      })
+      ngx.say("Status: " .. res.status)
+      ngx.say("Body:" .. res.body)
+
+      local res, err = httpc:request_uri("http://127.0.0.1:9080/.well-known/acme-challenge/foo", {
+        headers = {
+          ["Host"] = "example.com",
+        },
+      })
+      ngx.say("Challenge Status: " .. res.status)
+      ngx.print("Challenge Body: " .. res.body)
+    }
+  }
+--- request
+GET /t
+--- response_body
+Status: 200
+Body:
+Challenge Status: 200
+Challenge Body: bar
+--- no_error_log
+[error]
+[warn]
+[alert]
+[emerg]

--- a/t/memory.t
+++ b/t/memory.t
@@ -60,6 +60,8 @@ __DATA__
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -169,6 +171,8 @@ auto-ssl: issuing new certificate for
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()

--- a/t/multiple_workers.t
+++ b/t/multiple_workers.t
@@ -80,6 +80,8 @@ $TEST_NGINX_USER
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()

--- a/t/redis.t
+++ b/t/redis.t
@@ -73,6 +73,8 @@ __DATA__
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -207,6 +209,8 @@ auto-ssl: issuing new certificate for
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -337,6 +341,8 @@ issuing new certificate for
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -472,6 +478,8 @@ dehydrated succeeded, but certs still missing from storage
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -63,6 +63,8 @@ __DATA__
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -176,6 +178,8 @@ auto-ssl: issuing new certificate for
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -289,6 +293,8 @@ issuing new certificate for
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -393,6 +399,8 @@ lua ssl certificate verify error: (18: self signed certificate)
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -505,6 +513,8 @@ lua ssl certificate verify error: (18: self signed certificate)
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -617,6 +627,8 @@ lua ssl certificate verify error: (18: self signed certificate)
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -725,6 +737,8 @@ lua ssl certificate verify error: (18: self signed certificate)
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -834,6 +848,8 @@ lua ssl certificate verify error: (18: self signed certificate)
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -985,6 +1001,8 @@ lua ssl certificate verify error: (18: self signed certificate)
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()
@@ -1103,6 +1121,8 @@ lua ssl certificate verify error: (18: self signed certificate)
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()

--- a/t/sockproc_file_descriptors.t
+++ b/t/sockproc_file_descriptors.t
@@ -75,6 +75,8 @@ user $TEST_NGINX_NOBODY_USER $TEST_NGINX_NOBODY_GROUP;
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()

--- a/t/worker_file_permissions.t
+++ b/t/worker_file_permissions.t
@@ -72,6 +72,8 @@ user $TEST_NGINX_NOBODY_USER $TEST_NGINX_NOBODY_GROUP;
 
   server {
     listen 127.0.0.1:8999;
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()


### PR DESCRIPTION
This eliminates potential issues if the HTTP POST size to the hook server containing the cert exceeded nginx's default buffer size (which would prevent the hook server from being able to parse the POST args): https://github.com/GUI/lua-resty-auto-ssl/issues/65

Based on some quick tests, it looks like the POST to `/deploy-cert`, containing the certificate chain and private key was the largest POST.  These look to be in the neighborhood of 10KB, while nginx's default `client_body_buffer_size` might be either 8KB or 16KB depending on the exact system architecture. To address this, increase the suggested configuration in the README to 128KB (which is probably overkill, but provides plenty of space in case Let's Encrypt's full certificate chain ever becomes bigger).

This also adds some better error logging and error handling to the hook server, and adds more specific tests around the hook server.