### PR TITLE
Pass ssl_options to allow_domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ http {
 Additional configuration options can be set on the `auto_ssl` instance that is created:
 
 ### `allow_domain`
-*Default:* `function(domain, auto_ssl) return false end`
+*Default:* `function(domain, auto_ssl, ssl_options) return false end`
 
 A function that determines whether the incoming domain should automatically issue a new SSL certificate.
 
@@ -153,6 +153,8 @@ auto_ssl:set("allow_domain", function(domain, auto_ssl)
   return ngx.re.match(domain, "^(example.com|example.net)$", "ijo")
 end)
 ```
+
+Use `ssl_options` to make the behavior vary based on port - see the example in listed for `request_domain` for details.
 
 ### `dir`
 *Default:* `/etc/resty-auto-ssl`

--- a/lib/resty/auto-ssl/ssl_certificate.lua
+++ b/lib/resty/auto-ssl/ssl_certificate.lua
@@ -122,7 +122,7 @@ local function get_cert_der(auto_ssl_instance, domain, ssl_options)
   -- We may want to consider caching the results of allow_domain lookups
   -- (including negative caching or disallowed domains).
   local allow_domain = auto_ssl_instance:get("allow_domain")
-  if not allow_domain(domain, auto_ssl_instance) then
+  if not allow_domain(domain, auto_ssl_instance, ssl_options) then
     return nil, "domain not allowed"
   end
 


### PR DESCRIPTION
This allows different checks based on the port the request came in.