### PR TITLE
Don't store cert backups

### DIFF
--- a/lib/resty/auto-ssl/storage.lua
+++ b/lib/resty/auto-ssl/storage.lua
@@ -56,11 +56,6 @@ function _M.set_cert(self, domain, fullchain_pem, privkey_pem, cert_pem, expiry)
     return nil, err
   end
 
-  -- Store the cert with the current timestamp, so the old certs are preserved
-  -- in case something goes wrong.
-  local time = ngx.now() * 1000
-  self.adapter:set(domain .. ":" .. time, string)
-
   -- Store the cert under the "latest" alias, which is what this app will use.
   return self.adapter:set(domain .. ":latest", string)
 end


### PR DESCRIPTION
Those are inconvenient if you don't want to run Redis as LRU cache. We are more interested in not silently discarding any certificates, and scaling Redis with increasing number of domains, so we don't.

If this change is not acceptable, another scheme could be to store the previous (":old") certificate in addition to the current one (":latest"). This way we'd only be storing at most two certificates per domain in Redis, and not a growing number due to renewals.