### PR TITLE
Delete certificates that can't be renewed

### DIFF
--- a/lib/resty/auto-ssl/storage.lua
+++ b/lib/resty/auto-ssl/storage.lua
@@ -65,6 +65,10 @@ function _M.set_cert(self, domain, fullchain_pem, privkey_pem, cert_pem, expiry)
   return self.adapter:set(domain .. ":latest", string)
 end
 
+function _M.delete_cert(self, domain)
+  return self.adapter:delete(domain .. ":latest")
+end
+
 function _M.all_cert_domains(self)
   local keys, err = self.adapter:keys_with_suffix(":latest")
   if err then
@@ -131,6 +135,25 @@ function _M.issue_cert_unlock(self, domain, lock_rand_value)
   else
     return false, err
   end
+end
+
+function _M.get_renewal_count(self, domain)
+  local value, err = self.adapter:get(domain .. ":renewal_count")
+  if err then
+    return 0
+  elseif not value then
+    return 0
+  else
+    return tonumber(value)
+  end
+end
+
+function _M.set_renewal_count(self, domain, value)
+  return self.adapter:set(domain .. ":renewal_count", value)
+end
+
+function _M.delete_renewal_count(self, domain)
+  return self.adapter:delete(domain .. ":renewal_count")
 end
 
 return _M


### PR DESCRIPTION
The current released version will attempt a daily renewal forever once a domain's certificate has been stored. But domain holder's might move their domains elsewhere at any point, meaning that this renewal might never again succeed.

To limit the resources we spend daily on attempting a renewal for those, give up after the certificate has expired, and delete it from storage.