### PR TITLE
request_domain can set fullchain_der, privkey_der on ssl_options

### DIFF
--- a/lib/resty/auto-ssl/ssl_certificate.lua
+++ b/lib/resty/auto-ssl/ssl_certificate.lua
@@ -102,9 +102,16 @@ local function issue_cert(auto_ssl_instance, storage, domain)
 end
 
 local function get_cert_der(auto_ssl_instance, domain, ssl_options)
-  -- Look for the certificate in shared memory first.
-  local fullchain_der = ngx.shared.auto_ssl:get("domain:fullchain_der:" .. domain)
-  local privkey_der = ngx.shared.auto_ssl:get("domain:privkey_der:" .. domain)
+  local fullchain_der, privkey_der
+  if ssl_options["fullchain_der"] and ssl_options["privkey_der"] then
+    -- Look in ssl_options first in case request_domain has set it
+    fullchain_der = ssl_options["fullchain_der"]
+    privkey_der = ssl_options["privkey_der"]
+  else
+    -- Look for the certificate in shared memory first.
+    fullchain_der = ngx.shared.auto_ssl:get("domain:fullchain_der:" .. domain)
+    privkey_der = ngx.shared.auto_ssl:get("domain:privkey_der:" .. domain)
+  end
   if fullchain_der and privkey_der then
     return {
       fullchain_der = fullchain_der,


### PR DESCRIPTION
Hi,

i needed this in order to provide a wildcard certificate:
- does not fill autossl cache with a copy for each domain
- uses autossl ocsp logic to avoid nginx taking over

It requires some extra work in `init_by_lua`, see this [example](https://github.com/pageboard/server/blob/480172f41ec5ad76a64e7de721ec491482b3c194/nginx/pageboard.conf#L25-L64).


