### PR TITLE
Check whether domains are allowed on renewals

### DIFF
--- a/lib/resty/auto-ssl/jobs/renewal.lua
+++ b/lib/resty/auto-ssl/jobs/renewal.lua
@@ -129,6 +129,13 @@ local function renew_check_cert(auto_ssl_instance, storage, domain)
     end
   end
 
+  -- Check if domain is still allowed before renewing.
+  local allow_domain = auto_ssl_instance:get("allow_domain")
+  if not allow_domain(domain) then
+    ngx.log(ngx.NOTICE, "auto-ssl: domain not allowed, not renewing: ", domain)
+    return
+  end
+
   -- We didn't previously store the cert.pem (since it can be derived from the
   -- fullchain.pem). So for backwards compatibility, set the cert.pem value to
   -- the fullchain.pem value, since that should work for our date checking


### PR DESCRIPTION
Call allow_domain on renewals, so that it is possible to avoid renewing domains that are not allowed anymore e.g. have expired, dns doesn't resolve anymore etc. using custom code in the allow_domain function.

Thanks to @brianlund who posted this in https://github.com/GUI/lua-resty-auto-ssl/issues/150

This fixes https://github.com/GUI/lua-resty-auto-ssl/issues/101 and at least partially also https://github.com/GUI/lua-resty-auto-ssl/issues/150