### PR TITLE
[POC/RFC] Add OpenSSL provider support

### DIFF
--- a/bin/openssl_hooks
+++ b/bin/openssl_hooks
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# OpenSSL, by definition, is run locally. To pass back its execution state
+# it will call this hooks script.
+# For more details regarding internals see letsencrypt_hooks.
+
+set -Eeuo pipefail
+
+deploy_cert() {
+  local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}"
+  local EXPIRY
+  if ! EXPIRY=$(openssl x509 -enddate -noout -in "$CERTFILE"); then
+    echo "failed to get the expiry date"
+  fi
+
+  curl --silent --show-error --fail -XPOST \
+    --header "X-Hook-Secret: $HOOK_SECRET" \
+    --data-urlencode "domain=$DOMAIN" \
+    --data-urlencode "privkey@$KEYFILE" \
+    --data-urlencode "cert@$CERTFILE" \
+    --data-urlencode "fullchain@$FULLCHAINFILE" \
+    --data-urlencode "expiry=$EXPIRY" \
+    "http://127.0.0.1:$HOOK_SERVER_PORT/deploy-cert" || { echo "hook request (deploy_cert) failed" 1>&2; exit 1; }
+}
+
+unchanged_cert() {
+  local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}"
+}
+
+request_failure() {
+  local STATUSCODE="${1}" REASON="${2}"
+  echo "Failure: STATUSCODE=${STATUSCODE} REASON=${REASON} REQTYPE=${REQTYPE}"
+  exit 1
+}
+
+startup_hook() {
+  :
+}
+
+exit_hook() {
+  :
+}
+
+HANDLER=$1; shift;
+
+if ! command -v "$HANDLER"; then
+  exit 0
+fi
+
+$HANDLER "$@"

--- a/bin/openssl_manager
+++ b/bin/openssl_manager
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# This script is responsible for the actual certificates generation/renewal
+# It's like dehydrated but for OpenSSL. As of now it makes the following assumptions:
+#  - First parameter is always the config file; leave empty to use defaults [below]
+#  - Second parameter is always the hook file; cannot be empty (pass "true" if you REALLY want)
+
+set -Eeuo pipefail
+
+# Default configuration
+BASEDIR="/etc/resty-auto-ssl/openssl"
+CERTSDIR="${BASEDIR}/certs"
+CACRT="${CERTSDIR}/_ca.crt"
+INTCACRT="${CERTSDIR}/_int.crt"
+SIGNKEY="${CERTSDIR}/_sign.key"
+KEYSPEC="rsa:2048"
+CRTEXPDAYS="14"
+SUBJECT="/C=WW/ST=/L=/O=/CN=<domain>"
+OSLCFG="keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = <domain>"
+
+if [[ ! -z "${MANAGER_CFG:-}" ]] && [[ -f "${MANAGER_CFG}" ]] ; then
+   echo "[*] Loading custom config ${MANAGER_CFG}"
+   #shellcheck source=/dev/null
+  . "${CFGFILE}"
+fi
+
+if [[ -z "${HOOK_BIN:-}" ]] ; then
+   echo "[?] No HOOK_BIN set"
+   HOOK_BIN="echo"
+fi
+
+mkdir -p "${BASEDIR}"
+mkdir -p "${CERTSDIR}"
+
+issue_cert() {
+  local DOMAIN="${1}"
+  local DOMAINDIR=${CERTSDIR}/${DOMAIN};
+  mkdir -p "${DOMAINDIR}"
+
+  [[ -z "${INTCACRT}" ]] && local SIGNCRT="${CACRT}" || local SIGNCRT="${INTCACRT}" # use intermediate cert if available
+  local OSLCFGFILE="${CERTSDIR}/openssl.cfg" # OpenSSL signing config  (deleted after)
+  local KEYFILE="${DOMAINDIR}/privkey.pem" # certificate private key
+  local CSRFILE="${DOMAINDIR}/request.csr" # signing request (deleted after)
+  local CERFILE="${DOMAINDIR}/cert.pem" # contains just new cert file
+  local CHAINFILE="${DOMAINDIR}/fullchain.pem" # contains intermediate + cert
+
+  echo "[*] Generating CSR for ${DOMAIN} to ${CSRFILE}"
+  openssl req -subj "${SUBJECT//<domain>/$DOMAIN}" -newkey "${KEYSPEC}" -nodes -keyout "${KEYFILE}" -out "${CSRFILE}" \
+    || _fail $? "OpenSSL failed failed to make CSR+KEY"
+
+  echo "[*] Signing CSR for ${DOMAIN}"
+  echo "${OSLCFG//<domain>/$DOMAIN}" > "${OSLCFGFILE}"
+  openssl x509 -req \
+    -in "${CSRFILE}" \
+    -CA "${SIGNCRT}" -CAkey "${SIGNKEY}" -CAcreateserial \
+    -out "${CERFILE}" \
+    -days "${CRTEXPDAYS}" -sha256 -extfile "${OSLCFGFILE}" \
+    || _fail $? "[-] OpenSSL failed failed to sign CSR"
+
+  echo "[*] Cleaning up"
+  rm "${OSLCFGFILE}" "${CSRFILE}"
+
+  echo "[*] Generating chain files"
+  cat "${CERFILE}" > "${CHAINFILE}"
+  if [[ -f "${INTCACRT}" ]] ; then
+    # shellcheck source=/dev/null
+    cat "${INTCACRT}" >> "${CHAINFILE}"
+  fi
+
+  echo "[+] Certificate for ${DOMAIN} issued successfully (${CERFILE}), calling hook"
+  "${HOOK_BIN}" deploy_cert "${DOMAIN}" "${KEYFILE}" "${CERFILE}" "${CHAINFILE}"
+}
+
+_fail() { # Args: code; reason text
+  echo "[-] ${2}" 1>&2
+  echo "[*] Calling request_failure hook"
+  "${HOOK_BIN}" request_failure "${1}" "${2}"
+  exit 1
+}
+
+HANDLER=$1; shift;
+
+if ! command -v "$HANDLER"; then
+  exit 0
+fi
+
+"${HOOK_BIN}" startup_hook
+$HANDLER "$@"
+"${HOOK_BIN}" exit_hook

--- a/lib/resty/auto-ssl.lua
+++ b/lib/resty/auto-ssl.lua
@@ -45,6 +45,10 @@ function _M.new(options)
     options["json_adapter"] = "resty.auto-ssl.json_adapters.cjson"
   end
 
+  if not options["ssl_provider"] then
+    options["ssl_provider"] = "resty.auto-ssl.ssl_providers.lets_encrypt"
+  end
+
   if not options["ocsp_stapling_error_level"] then
     options["ocsp_stapling_error_level"] = ngx.ERR
   end
@@ -55,6 +59,10 @@ function _M.new(options)
 
   if not options["hook_server_port"] then
     options["hook_server_port"] = 8999
+  end
+
+  if not options["openssl_config"] then
+    options["openssl_config"] = ""
   end
 
   return setmetatable({ options = options }, { __index = _M })


### PR DESCRIPTION
## Motives
`lua-resty-auto-ssl` is extremely useful in development environment as well as in production. However while LE is great and free, it's not flexible enough for all scenarios. OpenSSL bridges this gap giving ultimate control over the process.

## What this does?
In essence this PR adds a (pretty feature-complete) proof-of-concept of local OpenSSL integration in `lua-resty-auto-ssl`. By default compatibility is not broken in any way and the code behaves as before, so it can be deployed without any changes to the configuration.

## Scope of changes
- New SSL provider is added which implements standard OpenSSL flow:
    - Create CSR for a domain
    - Create private key
    - Sign CSR with intermediate CA key (if available), or main CA key
    - Bundle everything into chained PEM
- New binaries/shell scripts are shipped:
    - `openssl_manager` implements the logic of `lua-resty-auto-ssl` <=> OpenSSL interaction
    - `openssl_hooks` mirrors `letsencrypt_hooks` mimicking flow of `dehydrated` calling hooks script which then calls internal web server to deploy certs
- **OCSP stapling is made optional**: as of now if certificate passed had no OCSP it was treated as an error since LE certs should always have it. Local ones obviously don't and thus the information is persisted in logs but degraded down from an error
- New config option `ssl_provider` is added:
    - By default assumes `resty.auto-ssl.ssl_providers.lets_encrypt` (BC)
    - Can be set to `resty.auto-ssl.ssl_providers.openssl` to enable OpenSSL provider
- New config option `openssl_config` is added which accepts a path to POSIX shell script which can override options present in `openssl_manager`
- Logic of renewal, previously hardcoded, is moved to each ssl provider to implement; current LE logic is preserved in LE provider

## Current state
- It works for initial certificate issuance, as well as for renewal
- Error handling seems to be solid
- Documentation is not updated
- Tests aren't updated


## WDYT?
Is that something you will like merged?
cc: @GUI 