### PR TITLE
Forces the domain to be lowercase

### DIFF
--- a/lib/resty/auto-ssl/ssl_certificate.lua
+++ b/lib/resty/auto-ssl/ssl_certificate.lua
@@ -281,6 +281,9 @@ local function do_ssl(auto_ssl_instance, ssl_options)
     ngx.log(ngx.WARN, "auto-ssl: could not determine domain for request (SNI not supported?) - using fallback - " .. (domain_err or ""))
     return
   end
+  
+  -- Forces the domain to be lowercase
+  domain = domain:lower()
 
   -- Get or issue the certificate for this domain.
   local cert_der, get_cert_der_err = get_cert_der(auto_ssl_instance, domain, ssl_options)


### PR DESCRIPTION
Fixes problems with non lower case SNI requests - e.g. https://LuA-ReStY-AuTo-SsL.TlD

Solves this error:
```
issue_cert(): auto-ssl: issuing new certificate failed: dehydrated succeeded, but no certs present
auto-ssl: could not get certificate for LuA-ReStY-AuTo-SsL.TlD - using fallback - failed to get or issue certificate
````

Reproduce:
````
curl -i https://LuA-ReStY-AuTo-SsL.TlD 
````