### PR TITLE
Update source from git to https

### DIFF
--- a/lua-resty-auto-ssl-git-1.rockspec
+++ b/lua-resty-auto-ssl-git-1.rockspec
@@ -1,7 +1,7 @@
 package = "lua-resty-auto-ssl"
 version = "git-1"
 source = {
-  url = "git://github.com/GUI/lua-resty-auto-ssl.git",
+  url = "https://github.com/auto-ssl/lua-resty-auto-ssl.git",
 }
 description = {
   summary = "Automatic SSL handling for OpenResty",


### PR DESCRIPTION
As per the change observed by Git. They have improved their Git protocol security. In order to cope with it, the source needs to be updated from git protocol to HTTPS protocol.

More information: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

Executed Command:
luarocks install https://raw.githubusercontent.com/GUI/lua-resty-auto-ssl/master/lua-resty-auto-ssl-git-1.rockspec

Error: 
Cloning into 'lua-resty-auto-ssl'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
Error: Failed cloning git repository.