### PR TITLE
Remove non-zero exit code from hooks

### DIFF
--- a/bin/letsencrypt_hooks
+++ b/bin/letsencrypt_hooks
@@ -17,7 +17,7 @@ deploy_challenge() {
     --data-urlencode "domain=$DOMAIN" \
     --data-urlencode "token_filename=$TOKEN_FILENAME" \
     --data-urlencode "token_value=$TOKEN_VALUE" \
-    "http://127.0.0.1:$HOOK_SERVER_PORT/deploy-challenge" || { echo "hook request (deploy_challenge) failed" 1>&2; exit 1; }
+    "http://127.0.0.1:$HOOK_SERVER_PORT/deploy-challenge" || { echo "hook request (deploy_challenge) failed" 1>&2; }
 }
 
 clean_challenge() {
@@ -28,7 +28,7 @@ clean_challenge() {
     --data-urlencode "domain=$DOMAIN" \
     --data-urlencode "token_filename=$TOKEN_FILENAME" \
     --data-urlencode "token_value=$TOKEN_VALUE" \
-    "http://127.0.0.1:$HOOK_SERVER_PORT/clean-challenge" || { echo "hook request (clean_challenge) failed" 1>&2; exit 1; }
+    "http://127.0.0.1:$HOOK_SERVER_PORT/clean-challenge" || { echo "hook request (clean_challenge) failed" 1>&2; }
 }
 
 deploy_cert() {
@@ -45,7 +45,7 @@ deploy_cert() {
     --data-urlencode "cert@$CERTFILE" \
     --data-urlencode "fullchain@$FULLCHAINFILE" \
     --data-urlencode "expiry=$EXPIRY" \
-    "http://127.0.0.1:$HOOK_SERVER_PORT/deploy-cert" || { echo "hook request (deploy_cert) failed" 1>&2; exit 1; }
+    "http://127.0.0.1:$HOOK_SERVER_PORT/deploy-cert" || { echo "hook request (deploy_cert) failed" 1>&2; }
 }
 
 unchanged_cert() {
@@ -55,13 +55,11 @@ unchanged_cert() {
 invalid_challenge() {
   local DOMAIN="${1}" RESPONSE="${2}"
   echo "Invalid challenge: DOMAIN=${DOMAIN} RESPONSE=${RESPONSE}"
-  exit 1
 }
 
 request_failure() {
   local STATUSCODE="${1}" REASON="${2}" REQTYPE="${3}"
   echo "Failure: STATUSCODE=${STATUSCODE} REASON=${REASON} REQTYPE=${REQTYPE}"
-  exit 1
 }
 
 startup_hook() {


### PR DESCRIPTION
dehydrated runs with "-e", which exits on error, so when the invalid_challenge hook exited with a non-zero status (ie. error), that'd cause dehydrated to exit as well, and we'd never get to cleaning up these challenges, they'd just accumulate in storage indefinately.

By removing the non-zero exit code, dehydrated continues running, thus cleaning up the challenges.

As of https://github.com/dehydrated-io/dehydrated/commit/4b7a1e4c, there's some logging around non-zero exit codes.