### PR TITLE
Update upload artifact action version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           docker cp ${{ matrix.variant }}-test:/tmp/resty-auto-ssl-test /tmp/resty-auto-ssl-test
       - name: Upload Artifacts
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ matrix.variant }}-logs"
           path: /tmp/resty-auto-ssl-test


### PR DESCRIPTION
Versions v1 and v2 are no longer valid in actions, breaking CI