### PR TITLE
Upgrade deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           - openresty1.13
           - lua51
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Build Container
         run: docker-compose build ${{ matrix.variant }}
       - name: Lint
@@ -37,7 +37,8 @@ jobs:
           docker cp ${{ matrix.variant }}-test:/tmp/resty-auto-ssl-test /tmp/resty-auto-ssl-test
       - name: Upload Artifacts
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ matrix.variant }}-logs"
           path: /tmp/resty-auto-ssl-test
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v1 to v4
- Upgrade `actions/upload-artifact` from v1 to v4
- Add `if-no-files-found: ignore` to maintain backward compatibility with v1 behavior

## Problem

GitHub deprecated and disabled v1/v2 of the artifact actions, causing all CI pipeline runs to fail immediately with:

```
##[error]This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v1`.
```

Reference: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

## Test plan

- [ ] CI pipeline passes after merge