### PR TITLE
Add missing has_certificate.lua copy operation to Makefile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
       - "*"
   schedule:
     - cron: "18 7 * * *"
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build Container
-        run: docker-compose build ${{ matrix.variant }}
+        run: docker compose build ${{ matrix.variant }}
       - name: Lint
-        run: docker-compose run --rm ${{ matrix.variant }} make lint
+        run: docker compose run --rm ${{ matrix.variant }} make lint
       - name: Test
-        run: docker-compose run --name "${{ matrix.variant }}-test" ${{ matrix.variant }} make test
+        run: docker compose run --name "${{ matrix.variant }}-test" ${{ matrix.variant }} make test
       - name: Copy Artifacts
         if: always()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ install: check-dependencies
 	install -m 644 lib/resty/auto-ssl/utils/shell_execute.lua $(INST_LUADIR)/resty/auto-ssl/utils/shell_execute.lua
 	install -m 644 lib/resty/auto-ssl/utils/shuffle_table.lua $(INST_LUADIR)/resty/auto-ssl/utils/shuffle_table.lua
 	install -m 644 lib/resty/auto-ssl/utils/start_sockproc.lua $(INST_LUADIR)/resty/auto-ssl/utils/start_sockproc.lua
+    install -m 644 lib/resty/auto-ssl/utils/has_certificate.lua $(INST_LUADIR)/resty/auto-ssl/utils/has_certificate.lua
 	install -d $(INST_LUADIR)/resty/auto-ssl/vendor
 	install -m 644 lib/resty/auto-ssl/vendor/shell.lua $(INST_LUADIR)/resty/auto-ssl/vendor/shell.lua
 	install -d $(INST_BINDIR)/resty-auto-ssl


### PR DESCRIPTION
The current version will fail if you try to call has_certificate() because lib/resty/auto-ssl/utils/has_certificate.lua is not being copied in Makefile. This commit fixes this.